### PR TITLE
Listen to the port extracted from the new .env BACKEND_URL

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -168,6 +168,6 @@ api.post('/verify', async (req, res) => {
 	res.status(200).json({ verified: user.verified })
 })
 
-api.listen(process.env.PORT, async () => {
-	console.log(`Server is running on ${process.env.HOST}:${process.env.PORT}`)
+api.listen(port, async () => {
+	console.log(`Server is running on ${process.env.BACKEND_URL}`)
 })


### PR DESCRIPTION
`api.listen` was still using the old way to retrieve the port number from the .env file.
However, this was changed recently and we now retrieve the port from the BACKEND_URL and putting it in a global variable on line 47:
`let port: number`